### PR TITLE
fix: don't break words

### DIFF
--- a/src/content-script/styles.scss
+++ b/src/content-script/styles.scss
@@ -116,6 +116,7 @@
     font-size: 15px;
     line-height: 1.6;
     border-radius: 8px;
+    word-break: break-word;
 
     pre {
       margin-top: 10px;

--- a/src/content-script/styles.scss
+++ b/src/content-script/styles.scss
@@ -116,7 +116,6 @@
     font-size: 15px;
     line-height: 1.6;
     border-radius: 8px;
-    word-break: break-all;
 
     pre {
       margin-top: 10px;


### PR DESCRIPTION
I encountered error #30 and #35, which are the same as what I'm experiencing. I noticed that you have added https://github.com/josStorer/chatGPTBox/commit/18b7db22fa96056467a4cd10ff994636ac419b93 to resolve them, yet I'm still experiencing broken words.

I found that removing the CSS rule resolves the issue, but I'm unsure if it would cause any other problems.