### PR TITLE
change youtube/index.mjs to not confuse chatgpt or run out of tokens

### DIFF
--- a/src/content-script/site-adapters/youtube/index.mjs
+++ b/src/content-script/site-adapters/youtube/index.mjs
@@ -1,6 +1,11 @@
 import { cropText } from '../../../utils'
 import { config } from '../index.mjs'
 
+function replaceHtmlEntities(htmlString) { // This function was written by ChatGPT and modified by me (iamsirsammy)
+  const doc = new DOMParser().parseFromString(htmlString.replace("&amp;", "&"), 'text/html');
+  return doc.documentElement.innerText;
+}
+
 export default {
   init: async (hostname, userConfig, getInput, mountComponent) => {
     try {
@@ -44,9 +49,11 @@ export default {
         subtitleContent += subtitleData.substring(0, subtitleData.indexOf('<')) + ','
       }
 
+      subtitleContent = replaceHtmlEntities(subtitleContent.replace(",", " "))
+
       return cropText(
-        `Provide a brief summary of the video using concise language and incorporating the video title.` +
-          `The video title is:"${title}".The subtitle content is as follows:\n${subtitleContent}`,
+        `Provide a brief summary of the following video using concise language, still including all the important details, and incorporating the video title.` +
+          `The video title is "${title}". The subtitle content is as follows:\n${subtitleContent}`,
       )
     } catch (e) {
       console.log(e)

--- a/src/content-script/site-adapters/youtube/index.mjs
+++ b/src/content-script/site-adapters/youtube/index.mjs
@@ -46,10 +46,10 @@ export default {
       let subtitleContent = ''
       while (subtitleData.indexOf('">') !== -1) {
         subtitleData = subtitleData.substring(subtitleData.indexOf('">') + 2)
-        subtitleContent += subtitleData.substring(0, subtitleData.indexOf('<')) + ','
+        subtitleContent += subtitleData.substring(0, subtitleData.indexOf('<')) + ' '
       }
 
-      subtitleContent = replaceHtmlEntities(subtitleContent.replace(",", " "))
+      subtitleContent = replaceHtmlEntities(subtitleContent)
 
       return cropText(
         `Provide a brief summary of the following video using concise language, still including all the important details, and incorporating the video title.` +


### PR DESCRIPTION
This PR fixes formatting for subtitles to not confuse chatgpt, and slightly improves the prompt. This should make the result better. I've tested the added lines in console, but I haven't fully tested the extension like this yet as I don't have a good build environment for extensions yet. It should work fine.

Not related, but I've made a prototype for adding Replit support to this extension and it should be finished soon.