### PR TITLE
Put the cursor back to input area after the answer generated

### DIFF
--- a/src/components/InputBox/index.jsx
+++ b/src/components/InputBox/index.jsx
@@ -10,6 +10,7 @@ export function InputBox({ onSubmit, enabled }) {
 
   useEffect(() => {
     updateRefHeight(inputRef)
+    if (enabled) inputRef.current.focus()
   })
 
   const onKeyDown = (e) => {

--- a/src/components/InputBox/index.jsx
+++ b/src/components/InputBox/index.jsx
@@ -10,8 +10,11 @@ export function InputBox({ onSubmit, enabled }) {
 
   useEffect(() => {
     updateRefHeight(inputRef)
-    if (enabled) inputRef.current.focus()
   })
+
+  useEffect(() => {
+    if (enabled) inputRef.current.focus()
+  }, [enabled])
 
   const onKeyDown = (e) => {
     e.stopPropagation()


### PR DESCRIPTION
Everytime when I want to continue asking based on the previous answer, I have to put the cursor in the textarea manually, so it's better to put it back automatically if the reponse is done.