### PR TITLE
Align the "ask" button with the i18n keyword

### DIFF
--- a/src/components/InputBox/index.jsx
+++ b/src/components/InputBox/index.jsx
@@ -95,7 +95,7 @@ export function InputBox({ onSubmit, enabled, port, reverseResizeDir }) {
         }}
         onClick={handleKeyDownOrClick}
       >
-        {enabled ? t('Send') : t('Stop')}
+        {enabled ? t('Ask') : t('Stop')}
       </button>
     </div>
   )


### PR DESCRIPTION
Currently, "Send" is not included in the i18n keywords list, which results in missing translations in the other language other than English.