### PR TITLE
Changed youtube summary prompt for better formatting

### DIFF
--- a/src/content-script/site-adapters/youtube/index.mjs
+++ b/src/content-script/site-adapters/youtube/index.mjs
@@ -53,8 +53,8 @@ export default {
       subtitleContent = replaceHtmlEntities(subtitleContent)
 
       return cropText(
-        `Provide a brief summary of the following video using concise language, still including all the important details, and incorporating the video title.` +
-          `The video title is "${title}". The subtitle content is as follows:\n${subtitleContent}`,
+        `Provide a structured summary of the following video in markdown format, focusing on key takeaways and crucial information, and ensuring to include the video title. The summary should be easy to read and concise, yet comprehensive.` +
+        `The video title is "${title}". The subtitle content is as follows:\n${subtitleContent}`,
       )
     } catch (e) {
       console.log(e)


### PR DESCRIPTION
Changed the youtube summary prompt for better formatting by outputting the answer in markdown. Now it includes the title, summary and key takeaways as bullet points and titles.