### PR TITLE
Add missing chatgptPlus4Browsing in defaultConfig

### DIFF
--- a/src/config/index.mjs
+++ b/src/config/index.mjs
@@ -144,6 +144,7 @@ export const defaultConfig = {
     'chatgptFree35',
     'chatgptFree35Mobile',
     'chatgptPlus4',
+    'chatgptPlus4Browsing',
     'chatgptPlus4Mobile',
     'chatgptApi35',
     'bingFree4',


### PR DESCRIPTION
`chatgptPlus4Browsing` seemed to be missing in 597cc7c1c96f6c32e200000af48fd00347432a07, so that it didn't show up in the config menu