### PR TITLE
fix: bing error

### DIFF
--- a/src/services/clients/bing/index.mjs
+++ b/src/services/clients/bing/index.mjs
@@ -62,8 +62,6 @@ export default class BingAIClient {
           (this.options.userToken ? `_U=${this.options.userToken}` : undefined),
         Referer: 'https://www.bing.com/search?q=Bing+AI&showconv=1&FORM=hpcodx',
         'Referrer-Policy': 'origin-when-cross-origin',
-        // Workaround for request being blocked due to geolocation
-        'x-forwarded-for': '1.1.1.1',
       },
     }
     if (this.options.proxy) {


### PR DESCRIPTION
Solved the error "/turing/conversation/create: failed to parse response body..." by removing 'x-forwarded-for' cookie in bing request.

More info: [https://github.com/waylaidwanderer/node-chatgpt-api/issues/378](https://github.com/waylaidwanderer/node-chatgpt-api/issues/378)