### PR TITLE
Remove Peo Dragonfly Bot (deprecated)

### DIFF
--- a/src/config/index.mjs
+++ b/src/config/index.mjs
@@ -49,7 +49,6 @@ export const poeWebModelKeys = [
   'poeAiWebClaude100k',
   'poeAiWebCustom',
   'poeAiWebChatGpt',
-  'poeAiWebDragonfly',
 ]
 
 /**
@@ -85,7 +84,6 @@ export const Models = {
   waylaidwandererApi: { value: '', desc: 'Waylaidwanderer API (Github)' },
   poeAiWebCustom: { value: '', desc: 'Poe AI (Web, Custom)' },
   poeAiWebChatGpt: { value: 'chatgpt', desc: 'Poe AI (Web, ChatGPT)' },
-  poeAiWebDragonfly: { value: 'dragonfly', desc: 'Poe AI (Web, Dragonfly)' },
 }
 
 for (const modelName in Models) {

--- a/src/services/clients/poe/index.mjs
+++ b/src/services/clients/poe/index.mjs
@@ -143,8 +143,6 @@ export default class PoeAiClient {
       bot = 'a2'
     } else if (bot === 'chatgpt') {
       bot = 'chinchilla'
-    } else if (bot === 'dragonfly') {
-      bot = 'nutria'
     }
 
     this.bot = bot


### PR DESCRIPTION
[Dragonfly ](https://poe.com/Dragonfly) has been deprecated as of May 31, 2023.


![image](https://github.com/josStorer/chatGPTBox/assets/19733801/79a01bc4-2052-4e5d-8490-4aaaea583e72)
