### PR TITLE
fix: parse sse

### DIFF
--- a/src/utils/fetch-sse.mjs
+++ b/src/utils/fetch-sse.mjs
@@ -34,6 +34,7 @@ export async function fetchSSE(resource, options) {
         parser.feed(formattedStr)
       } catch (error) {
         console.debug('json error', error)
+        parser.feed(str)
       }
     }
 


### PR DESCRIPTION
请看图中的 Case，每个 chunk 并不是严格以 `data: ` 分隔的：

![CleanShot 2023-10-17 at 11 33 12@2x](https://github.com/josStorer/chatGPTBox/assets/20217146/23071456-a799-48a2-a768-53579250e789)

按照 `eventsource-parser` 的文档，你应该把 try catch 移动到 `onParse` 里面。

我是 API 的开发者，虽然这个 API 比较特别，但确实是解析的代码不够规范，我试了其他三四种客户端，均没有出现次问题。

我在本地测试时解决了这个问题。而且貌似还顺带解决了偶尔出现“�”的问题。
