### PR TITLE
Replace legacy gpt-3.5-turbo-0613 with the latest gpt-3.5-turbo-1106

### DIFF
--- a/src/config/index.mjs
+++ b/src/config/index.mjs
@@ -35,8 +35,7 @@ export const gptApiModelKeys = ['gptApiDavinci']
 export const chatgptApiModelKeys = [
   'chatgptApi35',
   'chatgptApi35_16k',
-  'chatgptApi35_0613',
-  'chatgptApi35_16k_0613',
+  'chatgptApi35_1106',
   'chatgptApi4_8k',
   'chatgptApi4_8k_0613',
   'chatgptApi4_32k',
@@ -78,11 +77,7 @@ export const Models = {
   chatgptPlus4Mobile: { value: 'gpt-4-mobile', desc: 'ChatGPT (Mobile, GPT-4)' },
   chatgptApi35: { value: 'gpt-3.5-turbo', desc: 'ChatGPT (GPT-3.5-turbo)' },
   chatgptApi35_16k: { value: 'gpt-3.5-turbo-16k', desc: 'ChatGPT (GPT-3.5-turbo-16k)' },
-  chatgptApi35_0613: { value: 'gpt-3.5-turbo-0613', desc: 'ChatGPT (GPT-3.5-turbo 0613)' },
-  chatgptApi35_16k_0613: {
-    value: 'gpt-3.5-turbo-16k-0613',
-    desc: 'ChatGPT (GPT-3.5-turbo-16k 0613)',
-  },
+  chatgptApi35_1106: { value: 'gpt-3.5-turbo-1106', desc: 'ChatGPT (GPT-3.5-turbo 1106)' },
   claude2WebFree: { value: 'claude-2', desc: 'Claude.ai (Web, Claude 2)' },
   claude2Api: { value: '', desc: 'Claude.ai (API, Claude 2)' },
   bingFree4: { value: '', desc: 'Bing (Web, GPT-4)' },


### PR DESCRIPTION
gpt-3.5-turbo-1106 with replace both of:
- gpt-3.5-turbo-0613
- gpt-3.5-turbo-16k-0613

Reference:
- https://platform.openai.com/docs/models/gpt-3-5
- https://openai.com/blog/new-models-and-developer-products-announced-at-devday#updated-gpt-3-5-turbo