### PR TITLE
Fix GPT-4 model name and confusion in names

### DIFF
--- a/src/config/index.mjs
+++ b/src/config/index.mjs
@@ -74,8 +74,8 @@ export const poeWebModelKeys = [
 export const Models = {
   chatgptFree35: { value: 'text-davinci-002-render-sha', desc: 'ChatGPT (Web)' },
 
-  chatgptPlus4: { value: 'gpt-4', desc: 'ChatGPT (Web, GPT-4)' },
-  chatgptPlus4Browsing: { value: 'gpt-4-gizmo', desc: 'ChatGPT (Web, GPT-4, ChatGPT Classic)' },
+  chatgptPlus4Browsing: { value: 'gpt-4', desc: 'ChatGPT (Web, GPT-4, browsing, analysis, DALL·E)' },
+  chatgptPlus4: { value: 'gpt-4-gizmo', desc: 'ChatGPT (Web, GPT-4, ChatGPT Classic)' },
 
   chatgptApi35: { value: 'gpt-3.5-turbo', desc: 'ChatGPT (GPT-3.5-turbo)' },
   chatgptApi35_16k: { value: 'gpt-3.5-turbo-16k', desc: 'ChatGPT (GPT-3.5-turbo-16k)' },

--- a/src/config/index.mjs
+++ b/src/config/index.mjs
@@ -75,7 +75,7 @@ export const Models = {
   chatgptFree35: { value: 'text-davinci-002-render-sha', desc: 'ChatGPT (Web)' },
 
   chatgptPlus4: { value: 'gpt-4', desc: 'ChatGPT (Web, GPT-4)' },
-  chatgptPlus4Browsing: { value: 'gpt-4-browsing', desc: 'ChatGPT (Web, GPT-4, Browsing)' },
+  chatgptPlus4Browsing: { value: 'gpt-4-gizmo', desc: 'ChatGPT (Web, GPT-4, ChatGPT Classic)' },
 
   chatgptApi35: { value: 'gpt-3.5-turbo', desc: 'ChatGPT (GPT-3.5-turbo)' },
   chatgptApi35_16k: { value: 'gpt-3.5-turbo-16k', desc: 'ChatGPT (GPT-3.5-turbo-16k)' },


### PR DESCRIPTION
Hi, 
I think the model "ChatGPT (Web, GPT-4, Browsing)" is using an old model "gpt-4-browsing" which is redirecting to "text-davinci-002-render-sha"

So I fixed it by editing the model to "gpt-4" With DALL·E, browsing and analysis:
![image](https://github.com/josStorer/chatGPTBox/assets/19733801/ee810257-f9f4-47dc-a478-5546bcf0e7c1)



and "gpt-4-gizmo" which used by "ChatGPT Classic" The latest version of GPT-4 with no additional capabilities:
![image](https://github.com/josStorer/chatGPTBox/assets/19733801/5115df42-37fe-4fed-ad86-2c1e56deaccb)


please double check this confusion in the new models

thanks