### PR TITLE
Update Azure OpenAI API version version to 2024-02-01

### DIFF
--- a/src/services/apis/azure-openai-api.mjs
+++ b/src/services/apis/azure-openai-api.mjs
@@ -24,7 +24,7 @@ export async function generateAnswersWithAzureOpenaiApi(port, question, session)
   await fetchSSE(
     `${config.azureEndpoint.replace(/\/$/, '')}/openai/deployments/${
       config.azureDeploymentName
-    }/chat/completions?api-version=2023-05-15`,
+    }/chat/completions?api-version=2024-02-01`,
     {
       method: 'POST',
       signal: controller.signal,


### PR DESCRIPTION
This API version is the replacement for the previous2023-05-15 GA API release.

Reference:
- https://learn.microsoft.com/en-us/azure/ai-services/openai/api-version-deprecation#latest-ga-api-release