### PR TITLE
Add the latest GPT-4o Web free version

### DIFF
--- a/src/config/index.mjs
+++ b/src/config/index.mjs
@@ -86,7 +86,7 @@ export const moonshotApiModelKeys = ['moonshot_v1_8k', 'moonshot_v1_32k', 'moons
  * @type {Object.<string,Model>}
  */
 export const Models = {
-  chatgptFree35: { value: 'text-davinci-002-render-sha', desc: 'ChatGPT (Web)' },
+  chatgptFree35: { value: 'text-davinci-002-render-sha', desc: 'ChatGPT (Web, GPT-3.5)' },
 
   chatgptFree4o: { value: 'gpt-4o', desc: 'ChatGPT (Web, GPT-4o)' },
 

--- a/src/config/index.mjs
+++ b/src/config/index.mjs
@@ -23,6 +23,7 @@ export const ModelMode = {
 
 export const chatgptWebModelKeys = [
   'chatgptFree35',
+  'chatgptFree4o',
   'chatgptPlus4',
   'chatgptFree35Mobile',
   'chatgptPlus4Browsing',
@@ -86,6 +87,8 @@ export const moonshotApiModelKeys = ['moonshot_v1_8k', 'moonshot_v1_32k', 'moons
  */
 export const Models = {
   chatgptFree35: { value: 'text-davinci-002-render-sha', desc: 'ChatGPT (Web)' },
+
+  chatgptFree4o: { value: 'gpt-4o', desc: 'ChatGPT (Web, GPT-4o)' },
 
   chatgptPlus4: { value: 'gpt-4', desc: 'ChatGPT (Web, GPT-4 All in one)' },
   chatgptPlus4Browsing: { value: 'gpt-4-gizmo', desc: 'ChatGPT (Web, GPT-4)' },


### PR DESCRIPTION
Hi there,

just received the latest model update for ChatGPT free account and added it to this lovely extension

![image](https://github.com/josStorer/chatGPTBox/assets/19733801/7197ddb3-ed9c-4c98-811f-40e306f71277)

![image](https://github.com/josStorer/chatGPTBox/assets/19733801/485be609-4635-468f-b77d-749bbfd1b163)

Also renamed the default model "ChatGPT (Web)" to "ChatGPT (Web, GPT-3.5)" 
![image](https://github.com/josStorer/chatGPTBox/assets/19733801/abc01ada-5064-4939-9e11-bf3e0fa05a22)

Thanks