### PR TITLE
Enable GPT-4o via API by default instead of GPT-4 Turbo

### DIFF
--- a/src/config/index.mjs
+++ b/src/config/index.mjs
@@ -263,7 +263,7 @@ export const defaultConfig = {
     'chatgptFree4o',
     'chatgptPlus4',
     'chatgptApi35',
-    'chatgptApi4_128k',
+    'chatgptApi4o_128k',
     'claude2WebFree',
     'bingFree4',
     'moonshotWebFree',


### PR DESCRIPTION
GPT-4o should be the one default enabled instead of GPT-4 Turbo 😄

As for the pricing and performance 🎉 

| Model        | Input              | Output             |
|--------------|--------------------|--------------------|
| gpt-4o       | $5.00 / 1M tokens  | $15.00 / 1M tokens |
| gpt-4-turbo  | $10.00 / 1M tokens | $30.00 / 1M tokens |

🏆 https://leaderboard.lmsys.org/