### PR TITLE
Add floating toolbar display mode option

### DIFF
--- a/src/config/index.mjs
+++ b/src/config/index.mjs
@@ -8,6 +8,11 @@ export const TriggerMode = {
   manually: 'Manually',
 }
 
+export const DisplayMode = {
+  sidebar: 'Display in sidebar',
+  floatingToolbar: 'Display in floating toolbar',
+}
+
 export const ThemeMode = {
   light: 'Light',
   dark: 'Dark',
@@ -202,6 +207,8 @@ export const defaultConfig = {
 
   /** @type {keyof TriggerMode}*/
   triggerMode: 'manually',
+  /** @type {keyof DisplayMode}*/
+  displayMode: 'sidebar',
   /** @type {keyof ThemeMode}*/
   themeMode: 'auto',
   /** @type {keyof Models}*/

--- a/src/content-script/index.jsx
+++ b/src/content-script/index.jsx
@@ -70,11 +70,33 @@ async function mountComponent(siteConfig, userConfig) {
     unmountComponentAtNode(e)
     e.remove()
   })
+
+  const position = {
+    x: window.innerWidth - 300 - (Math.floor((20 / 100) * window.innerWidth)),
+    y: window.innerHeight / 2 - 200,
+  }
+  const toolbarContainer = createElementAtPosition(position.x, position.y)
+  toolbarContainer.className = 'chatgptbox-toolbar-container-not-queryable'
+  if (userConfig.displayMode === 'floatingToolbar') {
+    render(
+      <FloatingToolbar
+        session={initSession({ modelName: userConfig.modelName })}
+        selection={question}
+        container={toolbarContainer}
+        dockable={true}
+        triggered={true}
+        closeable={true}
+        prompt={question}
+      />,
+      toolbarContainer,
+    )
+    return
+  }
   const container = document.createElement('div')
   container.id = 'chatgptbox-container'
   render(
     <DecisionCard
-      session={initSession({ modelName: (await getUserConfig()).modelName })}
+      session={initSession({ modelName: userConfig.modelName })}
       question={question}
       siteConfig={siteConfig}
       container={container}

--- a/src/popup/sections/GeneralPart.jsx
+++ b/src/popup/sections/GeneralPart.jsx
@@ -14,6 +14,7 @@ import {
   Models,
   ThemeMode,
   TriggerMode,
+  DisplayMode,
   isUsingMoonshotApi,
 } from '../../config/index.mjs'
 import Browser from 'webextension-polyfill'
@@ -112,6 +113,24 @@ export function GeneralPart({ config, updateConfig }) {
           {Object.entries(TriggerMode).map(([key, desc]) => {
             return (
               <option value={key} key={key} selected={key === config.triggerMode}>
+                {t(desc)}
+              </option>
+            )
+          })}
+        </select>
+      </label>
+      <label>
+        <legend>{t('DisplayMode')}</legend>
+        <select
+          required
+          onChange={(e) => {
+            const mode = e.target.value
+            updateConfig({ displayMode: mode })
+          }}
+        >
+          {Object.entries(DisplayMode).map(([key, desc]) => {
+            return (
+              <option value={key} key={key} selected={key === config.displayMode}>
                 {t(desc)}
               </option>
             )


### PR DESCRIPTION

Summary of changes:
This commit introduces a new display mode option for the ChatGPT extension, allowing users to choose between a sidebar and a floating toolbar. The changes span across three files, implementing the new feature and updating the configuration options.

Key changes:
1. In `src/config/index.mjs`:
   - Added a new `DisplayMode` object with two options: sidebar and floating toolbar.
   - Updated the `defaultConfig` object to include a `displayMode` property.

2. In `src/content-script/index.jsx`:
   - Implemented logic to render either the existing sidebar or the new floating toolbar based on the user's display mode preference.
   - Added code to create and position the floating toolbar container.

3. In `src/popup/sections/GeneralPart.jsx`:
   - Added a new dropdown menu in the extension's settings to allow users to select their preferred display mode.

Overall, this commit enhances the extension's flexibility by giving users the option to choose how they want the ChatGPT interface to be displayed on web pages.