### PR TITLE
Add the latest OpenAI "dynamic" model `chatgpt-4o-latest`

### DIFF
--- a/src/config/index.mjs
+++ b/src/config/index.mjs
@@ -47,6 +47,7 @@ export const chatgptApiModelKeys = [
   'chatgptApi35_1106',
   'chatgptApi35_0125',
   'chatgptApi4o_128k',
+  'chatgptApi4oLatest',
   'chatgptApi4oMini',
   'chatgptApi4_8k',
   'chatgptApi4_8k_0613',
@@ -195,6 +196,7 @@ export const Models = {
     value: 'gpt-4-0125-preview',
     desc: 'ChatGPT (GPT-4-Turbo 128k 0125 Preview)',
   },
+  chatgptApi4oLatest: { value: 'chatgpt-4o-latest', desc: 'ChatGPT (ChatGPT-4o latest)' },
 
   claude2WebFree: { value: '', desc: 'Claude.ai (Web)' },
   claude12Api: { value: 'claude-instant-1.2', desc: 'Claude.ai (API, Claude Instant 1.2)' },


### PR DESCRIPTION
Seems to be the most powerful one right now and will be continuously updated in the future. This also means we can save the steps to update the latest model.

Reference:
- https://x.com/OpenAIDevs/status/1823510395619000525
- https://x.com/lmsysorg/status/1823515224064098546
- https://x.com/lmsysorg/status/1823515229491515715
- https://platform.openai.com/docs/models/gpt-4o


> Dynamic model continuously updated to the current version of GPT-4o in ChatGPT. Intended for research and evaluation.
>
> We are releasing this model for developers and researchers to explore OpenAI's latest research. For production use, OpenAI recommends using dated GPT models, which are optimized for API usage.
>
> https://platform.openai.com/docs/models/gpt-4o#4ofootnote