### PR TITLE
Allow Anthropic APIs to send request in site adaptations, selection tools.

### DIFF
--- a/src/services/apis/claude-api.mjs
+++ b/src/services/apis/claude-api.mjs
@@ -30,6 +30,7 @@ export async function generateAnswersWithClaudeApi(port, question, session) {
       'Content-Type': 'application/json',
       'anthropic-version': '2023-06-01',
       'x-api-key': config.claudeApiKey,
+      'anthropic-dangerous-direct-browser-access': true,
     },
     body: JSON.stringify({
       model,


### PR DESCRIPTION
- Resolves #788 
- Due to Anthropic's policy, now normal API request will throw an CORS error. This PR fixes this issue by adding the bypass header when sending a request.